### PR TITLE
Add HTTP referer header to aiohttp requests

### DIFF
--- a/HostBot/host.py
+++ b/HostBot/host.py
@@ -36,7 +36,7 @@ class HostBot(Plugin):
     async def _reupload(self, message: str) -> Optional[MediaMessageEventContent]:
         url = message
         self.log.info(f"Reuploading {url}")
-        resp = await self.http.get(url)
+        resp = await self.http.get(url, headers={"Referer": url})
         data = await resp.read()
         img = Image.open(BytesIO(data))
         width, height = img.size


### PR DESCRIPTION
Add a really dumb policy for HTTP referer header (to bypass simple hotlink prevention schemes).